### PR TITLE
Remove the github ci for MacOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,10 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macOS-latest, ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the source code
         uses: actions/checkout@v1


### PR DESCRIPTION
## DESC

Due to https://github.com/patractlabs/jupiter/runs/1394651702

```
  error: dlsym(0x7f988285a810, __rustc_proc_macro_decls_9381f24f0e034f6bac9bfa906134d0c9__): symbol not found
    --> /Users/runner/.cargo/git/checkouts/polkadot-4038f27d5e4ea2e8/abc8c09/core-primitives/src/lib.rs:23:5
     |
  23 | use sp_runtime::{generic, MultiSignature, traits::{Verify, BlakeTwo256, IdentifyAccount}};
     |     ^^^^^^^^^^

  error: aborting due to previous error

  error: could not compile `polkadot-core-primitives`
```